### PR TITLE
Fix memory leak in worker.promise

### DIFF
--- a/src/worker.browser/worker.js
+++ b/src/worker.browser/worker.js
@@ -138,9 +138,19 @@ export default class Worker extends EventEmitter {
 
   promise() {
     return new Promise((resolve, reject) => {
+      let resolved, rejected;
+      resolved = (result) => {
+        this.removeListener('error', rejected);
+        resolve(result);
+      };
+      rejected = (err) => {
+        this.removeListener('message', resolved);
+        reject(err);
+      };
+
       this
-        .once('message', resolve)
-        .once('error', reject);
+        .once('message', resolved)
+        .once('error', rejected);
     });
   }
 

--- a/src/worker.node/worker.js
+++ b/src/worker.node/worker.js
@@ -62,9 +62,19 @@ export default class Worker extends EventEmitter {
 
   promise() {
     return new Promise((resolve, reject) => {
+      let resolved, rejected;
+      resolved = (result) => {
+        this.removeListener('error', rejected);
+        resolve(result);
+      };
+      rejected = (err) => {
+        this.removeListener('message', resolved);
+        reject(err);
+      };
+
       this
-        .once('message', resolve)
-        .once('error', reject);
+        .once('message', resolved)
+        .once('error', rejected);
     });
   }
 


### PR DESCRIPTION
Ran into a memory leak that I'm fairly certain is traced back to this. An event emitter handler bound via `.once` only gets removed when that event gets emitted, so the promise never removes both handlers, just whichever handler gets invoked first. Thus, every time .promise gets called, the promise() scope gets leaked.

This PR ensures that whichever state gets called first removes the handler for the other state.

I wasn't sure if I should commit the build artifacts for the PR (couldn't find any contribution guidelines), so I left them out. I can add if they're wanted.