### PR TITLE
Newer version apparently have a `v` in front of them

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ bower install --save threads
 <script src="https://cdn.rawgit.com/andywer/threads.js/__VERSION__/dist/threads.browser.min.js"></script>
 ```
 
-(where `__VERSION__` is the library's version to use, like `0.5.3`)
+(where `__VERSION__` is the library's version to use, like `v0.5.3`)
 
 
 ## How To

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ bower install --save threads
 <script src="https://cdn.rawgit.com/andywer/threads.js/__VERSION__/dist/threads.browser.min.js"></script>
 ```
 
-(where `__VERSION__` is the library's version to use, like `v0.5.3`)
+(where `__VERSION__` is the library's version to use, like `v0.7.2`)
 
 
 ## How To


### PR DESCRIPTION
I changed just one line in the README to make it clearer how to find the latest version of the script on rawgit.

Version 0.7.2 has a `v` (e.g. `v0.7.2`) in front of the number whereas the previous example (`0.5.3`) didn't.