### PR TITLE
Fix typo in bower "main" property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "threads",
   "version": "0.6.1",
-  "main": "dist/thread.browser.js",
+  "main": "dist/threads.browser.js",
   "homepage": "https://github.com/andywer/threads.js",
   "authors": [
     "Andy Wermke <andy@dev.next-step-software.com>"


### PR DESCRIPTION
Change "main" property in bower.json from "dist/thread.brower.js" to correct file name "dist/threads.brower.js"