### PR TITLE
Document edge case: arrow function

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ thread
     console.log('Worker has been terminated.');
   });
 ```
-
+If you are using arrow function syntax be sure to add brackets, e.g `(input, done) => { done() }` instead of `(input, done) => done()`.
 
 ## Installation
 


### PR DESCRIPTION
Add some documentation on using arrow functions without brackets because are used to separate the function body in `runMethod`.