### PR TITLE
Handle unhandled promise rejection in Node

### DIFF
--- a/src/worker.node/slave.js
+++ b/src/worker.node/slave.js
@@ -48,9 +48,9 @@ function messageHandlerProgress(progress) {
 }
 
 function messageHandlerError(error) {
-    process.send({
-        error : { message : error.message, stack : error.stack }
-    });
+  process.send({
+    error : { message : error.message, stack : error.stack }
+  });
 }
 
 process.on('message', function(data) {

--- a/src/worker.node/slave.js
+++ b/src/worker.node/slave.js
@@ -10,11 +10,8 @@ let messageHandler = function() {
 function setupErrorCatcher() {
   if (errorCatcherInPlace) { return; }
 
-  process.on('uncaughtException', function(error) {
-    process.send({
-      error : { message : error.message, stack : error.stack }
-    });
-  });
+  process.on('uncaughtException', messageHandlerError);
+  process.on('unhandledRejection', messageHandlerError);
 
   errorCatcherInPlace = true;
 }
@@ -50,6 +47,11 @@ function messageHandlerProgress(progress) {
   process.send({ progress });
 }
 
+function messageHandlerError(error) {
+    process.send({
+        error : { message : error.message, stack : error.stack }
+    });
+}
 
 process.on('message', function(data) {
   if (data.initByScript) {

--- a/test/spec/worker.spec.js
+++ b/test/spec/worker.spec.js
@@ -203,6 +203,18 @@ describe('Worker', function () {
 
   if (env === 'node') {
 
+    it('can emit error on unhandled promise rejection', done => {
+      const worker = spawn(() => {
+        new Promise((resolve, reject) => reject(new Error('Test message')));
+      });
+
+      worker.on('error', error => {
+        expect(error.message).to.match(/^((Uncaught )?Error: )?Test message$/);
+        done();
+      });
+      worker.send();
+    });
+
     it('thread code can use setTimeout, setInterval', done => {
       let messageCount = 0;
 


### PR DESCRIPTION
Done only for node, because corresponding [browser api](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onunhandledrejection) is not yet supported for [workers](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope) by any vendor.

Fixes #49 