### PR TITLE
Adding progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # threads.js - Changelog
 
+## Next release
+
+- Job class now emits 'progress' events
+[#56](https://github.com/andywer/threads.js/pull/56)
+- Credits to https://github.com/mmcardle
+
 ## 0.7.3
 
 - Trigger worker error event on unhandled promise rejection in worker [#49](https://github.com/andywer/threads.js/issues/49)

--- a/src/job.js
+++ b/src/job.js
@@ -33,19 +33,15 @@ export default class Job extends EventEmitter {
     return this;
   }
 
-  onProgress(progress){
-    this.emit('progress', progress);
-  }
-
   executeOn(thread) {
     const onProgress = (...args) => this.emit('progress', ...args);
     const onMessage = (...args) => {
       this.emit('message', ...args);
-      this.removeListener('progress', onProgress);
+      thread.removeListener('progress', onProgress);
     };
     const onError = (...args) => {
       this.emit('error', ...args);
-      this.removeListener('progress', onProgress);
+      thread.removeListener('progress', onProgress);
     };
     
     thread

--- a/src/job.js
+++ b/src/job.js
@@ -35,6 +35,8 @@ export default class Job extends EventEmitter {
 
   executeOn(thread) {
     thread
+      .off('progress')
+      .on('progress', (e) => {this.emit('progress', e)} )
       .once('message', this.emit.bind(this, 'done'))
       .once('error', this.emit.bind(this, 'error'))
       .run(...this.runArgs)

--- a/src/job.js
+++ b/src/job.js
@@ -38,10 +38,20 @@ export default class Job extends EventEmitter {
   }
 
   executeOn(thread) {
+    const onProgress = (...args) => this.emit('progress', ...args);
+    const onMessage = (...args) => {
+      this.emit('message', ...args);
+      this.removeListener('progress', onProgress);
+    };
+    const onError = (...args) => {
+      this.emit('error', ...args);
+      this.removeListener('progress', onProgress);
+    };
+    
     thread
-      .on('progress', this.onProgress.bind(this))
-      .once('message', this.emit.bind(this, 'done'))
-      .once('error', this.emit.bind(this, 'error'))
+      .on('progress', onProgress)
+      .once('message', onMessage)
+      .once('error', onError)
       .run(...this.runArgs)
       .send(...this.sendArgs);
 

--- a/src/job.js
+++ b/src/job.js
@@ -36,7 +36,7 @@ export default class Job extends EventEmitter {
   executeOn(thread) {
     const onProgress = (...args) => this.emit('progress', ...args);
     const onMessage = (...args) => {
-      this.emit('message', ...args);
+      this.emit('done', ...args);
       thread.removeListener('progress', onProgress);
     };
     const onError = (...args) => {

--- a/src/job.js
+++ b/src/job.js
@@ -33,10 +33,13 @@ export default class Job extends EventEmitter {
     return this;
   }
 
+  onProgress(progress){
+    this.emit('progress', progress);
+  }
+
   executeOn(thread) {
     thread
-      .off('progress')
-      .on('progress', (e) => {this.emit('progress', e)} )
+      .on('progress', this.onProgress.bind(this))
       .once('message', this.emit.bind(this, 'done'))
       .once('error', this.emit.bind(this, 'error'))
       .run(...this.runArgs)

--- a/test/spec/job.spec.js
+++ b/test/spec/job.spec.js
@@ -80,7 +80,9 @@ describe('Job', () => {
     const thread = {
       once : noop,
       run  : noop,
-      send : noop
+      send : noop,
+      off  : noop,
+      on   : noop,
     };
     const mock = sinon.mock(thread);
 
@@ -92,6 +94,8 @@ describe('Job', () => {
 
     mock.expects('run').once().withArgs(runnable, importScripts).returnsThis();
     mock.expects('send').once().withArgs(param, transferables).returnsThis();
+    mock.expects('off').once().withArgs('progress').returnsThis();
+    mock.expects('on').once().withArgs('progress').returnsThis();
 
     job
       .run(runnable, importScripts)

--- a/test/spec/job.spec.js
+++ b/test/spec/job.spec.js
@@ -81,8 +81,7 @@ describe('Job', () => {
       once : noop,
       run  : noop,
       send : noop,
-      off  : noop,
-      on   : noop,
+      on   : noop
     };
     const mock = sinon.mock(thread);
 
@@ -94,7 +93,6 @@ describe('Job', () => {
 
     mock.expects('run').once().withArgs(runnable, importScripts).returnsThis();
     mock.expects('send').once().withArgs(param, transferables).returnsThis();
-    mock.expects('off').once().withArgs('progress').returnsThis();
     mock.expects('on').once().withArgs('progress').returnsThis();
 
     job


### PR DESCRIPTION
The purpose of this PR is to allow progress reports from jobs when they are executed and also when they are submitted to a Pool.

- [x] Check if we need to remove the progress listener when the job is destroyed  
- [x] Provide summary of changes
- [ ] Add docs
- [x] Add more tests for checking progress