### PR TITLE
Fix use of path-or-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const spawn   = threads.spawn;
 // Set base paths to thread scripts
 config.set({
   basepath : {
-    browser : 'http://myserver.local/thread-scripts',
+    web : 'http://myserver.local/thread-scripts',
     node    : __dirname + '/../thread-scripts'
   }
 });

--- a/src/worker.browser/worker.js
+++ b/src/worker.browser/worker.js
@@ -18,11 +18,12 @@ function joinPaths (path1, path2) {
 }
 
 function prependScriptUrl(scriptUrl) {
-  let prefix = getConfig().basepath.web;
-  if (prefix && prefix.startsWith('/')) {
-    prefix = `${document.location.protocol}//${document.location.host}${prefix}`;
+  let basePath = getConfig().basepath.web;
+  if (basePath && !basePath.match(/^\w+:\/\//)) {
+    // Turn path into full URL, since referencing a `http://` path from a `blob://` URL won't work
+    basePath = `${document.location.protocol}//${document.location.host}${basePath}`;
   }
-  return prefix ? joinPaths(prefix, scriptUrl) : scriptUrl;
+  return basePath ? joinPaths(basePath, scriptUrl) : scriptUrl;
 }
 
 function argsToArray(argumentsList) {

--- a/src/worker.browser/worker.js
+++ b/src/worker.browser/worker.js
@@ -18,7 +18,10 @@ function joinPaths (path1, path2) {
 }
 
 function prependScriptUrl(scriptUrl) {
-  const prefix = getConfig().basepath.web;
+  let prefix = getConfig().basepath.web;
+  if (prefix && prefix.startsWith('/')) {
+    prefix = `${document.location.protocol}//${document.location.host}${prefix}`;
+  }
   return prefix ? joinPaths(prefix, scriptUrl) : scriptUrl;
 }
 


### PR DESCRIPTION
This mini commit makes the code example reflect the code (`config.browser` vs `config.web`) and takes care about the _path_ part of _path-or-url_.

Problem is (at least with a current chrome), that the script is not loaded when using an absolute path. It seems to require a full URL.

closes #62