### PR TITLE
Fix readme: basepath.browser => basepath.web

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ const spawn   = threads.spawn;
 // Set base paths to thread scripts
 config.set({
   basepath : {
-    browser : 'http://myserver.local/thread-scripts',
-    node    : __dirname + '/../thread-scripts'
+    node : __dirname + '/../thread-scripts',
+    web  : 'http://myserver.local/thread-scripts'
   }
 });
 


### PR DESCRIPTION
Follow-up PR of #63 by @cajus: Just changing the README, no code changes.

Background: #63 does not build right now. Maybe we can at least merge the documentation fix.