### PR TITLE
Add option parameter to Pool for passing arguments to worker processes

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,9 @@ const configuration = {
   },
   fallback : {
     slaveScriptUrl : ''
+  },
+  forkOptions : {
+    execArgv: []
   }
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -5,9 +5,6 @@ const configuration = {
   },
   fallback : {
     slaveScriptUrl : ''
-  },
-  workerOptions : {
-    execArgv: []
   }
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -6,7 +6,7 @@ const configuration = {
   fallback : {
     slaveScriptUrl : ''
   },
-  forkOptions : {
+  workerOptions : {
     execArgv: []
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ import Worker   from './worker';
 
 export { config, defaults, Pool };
 
-export function spawn(runnable = null, importScripts = []) {
-  return new Worker(runnable, importScripts);
+export function spawn(runnable = null, importScripts = [], options = {}) {
+  return new Worker(runnable, importScripts, options);
 }
 
 export default {

--- a/src/pool.js
+++ b/src/pool.js
@@ -4,9 +4,9 @@ import defaults     from './defaults';
 import { spawn }    from './';
 
 export default class Pool extends EventEmitter {
-  constructor(threads) {
+  constructor(threads, options = {}) {
     super();
-    this.threads = Pool.spawn(threads || defaults.pool.size);
+    this.threads = Pool.spawn(threads || defaults.pool.size, options);
     this.idleThreads = this.threads.slice();
     this.jobQueue = [];
     this.runArgs = [];
@@ -81,11 +81,11 @@ export default class Pool extends EventEmitter {
   }
 }
 
-Pool.spawn = (threadCount) => {
+Pool.spawn = (threadCount, options) => {
   const threads = [];
 
   for (let threadIndex = 0; threadIndex < threadCount; threadIndex++) {
-    threads.push(spawn());
+    threads.push(spawn(null, [], options));
   }
 
   return threads;

--- a/src/worker.node/worker.js
+++ b/src/worker.node/worker.js
@@ -6,7 +6,7 @@ import { getConfig } from '../config';
 
 
 export default class Worker extends EventEmitter {
-  constructor(initialRunnable, importScripts, options) {
+  constructor(initialRunnable, importScripts = [], options = {}) {
     super();
 
     this.slave = child.fork(path.join(__dirname, 'slave.js'), [], options);

--- a/src/worker.node/worker.js
+++ b/src/worker.node/worker.js
@@ -7,8 +7,9 @@ import { getConfig } from '../config';
 
 export default class Worker extends EventEmitter {
   constructor(initialRunnable, importScripts = [], options = {}) {
+    // `importScripts` cannot be consumed, it's just there to keep the API compatible to the browser worker
     super();
-
+    
     this.slave = child.fork(path.join(__dirname, 'slave.js'), [], options);
     this.slave.on('message', this.handleMessage.bind(this));
     this.slave.on('error', this.handleError.bind(this));

--- a/src/worker.node/worker.js
+++ b/src/worker.node/worker.js
@@ -10,8 +10,8 @@ export default class Worker extends EventEmitter {
     super();
 
     const config = getConfig();
-    if (config.forkOptions.execArgv.length > 0) {
-      options.execArgv = (options.execArgv === undefined ? config.forkOptions.execArgv : options.execArgv.concat(config.forkOptions.execArgv));
+    if (config.workerOptions.execArgv.length > 0) {
+      options.execArgv = (options.execArgv === undefined ? config.workerOptions.execArgv : options.execArgv.concat(config.workerOptions.execArgv));
     }
 
     this.slave = child.fork(path.join(__dirname, 'slave.js'), [], options);

--- a/src/worker.node/worker.js
+++ b/src/worker.node/worker.js
@@ -6,13 +6,8 @@ import { getConfig } from '../config';
 
 
 export default class Worker extends EventEmitter {
-  constructor(initialRunnable, options = {}) {
+  constructor(initialRunnable, importScripts, options) {
     super();
-
-    const config = getConfig();
-    if (config.workerOptions.execArgv.length > 0) {
-      options.execArgv = (options.execArgv === undefined ? config.workerOptions.execArgv : options.execArgv.concat(config.workerOptions.execArgv));
-    }
 
     this.slave = child.fork(path.join(__dirname, 'slave.js'), [], options);
     this.slave.on('message', this.handleMessage.bind(this));

--- a/src/worker.node/worker.js
+++ b/src/worker.node/worker.js
@@ -9,6 +9,11 @@ export default class Worker extends EventEmitter {
   constructor(initialRunnable, options = {}) {
     super();
 
+    const config = getConfig();
+    if (config.forkOptions.execArgv.length > 0) {
+      options.execArgv = (options.execArgv === undefined ? config.forkOptions.execArgv : options.execArgv.concat(config.forkOptions.execArgv));
+    }
+
     this.slave = child.fork(path.join(__dirname, 'slave.js'), [], options);
     this.slave.on('message', this.handleMessage.bind(this));
     this.slave.on('error', this.handleError.bind(this));

--- a/test/spec/worker.spec.js
+++ b/test/spec/worker.spec.js
@@ -197,7 +197,6 @@ describe('Worker', function () {
     }
   });
 
-
   if (env === 'node') {
 
     it('can emit error on unhandled promise rejection', done => {
@@ -231,6 +230,38 @@ describe('Worker', function () {
         });
     });
 
+    describe('handle option parameters', () => {
+      let worker;
+      let initialArgs;
+
+      before(() => {
+        initialArgs = process.execArgv;
+      });
+
+      after(() => {
+        process.execArgv = initialArgs;
+      });
+
+      afterEach(() => {
+        worker.kill();
+      });
+
+      it('can override options', done => {
+        process.execArgv=['--arg1'];
+        worker = spawn(null, [], { execArgv: ['--arg2'] });
+        expect(worker.slave.spawnargs[1]).to.eql('--arg2');
+        worker.kill();
+        done();
+      });
+
+      it('default options', done => {
+        process.execArgv=['--arg1'];
+        worker = spawn(null, [], {});
+        expect(worker.slave.spawnargs[1]).to.eql('--arg1');
+        worker.kill();
+        done();
+      });
+    });
   }
 
 

--- a/test/spec/worker.spec.js
+++ b/test/spec/worker.spec.js
@@ -49,9 +49,6 @@ describe('Worker', function () {
         basepath : {
           node : __dirname + '/../thread-scripts',
           web  : 'http://localhost:9876/base/test/thread-scripts'
-        },
-        workerOptions: {
-          execArgv: []
         }
       });
   });

--- a/test/spec/worker.spec.js
+++ b/test/spec/worker.spec.js
@@ -253,14 +253,6 @@ describe('Worker', function () {
         worker.kill();
         done();
       });
-
-      it('default options', done => {
-        process.execArgv=['--arg1'];
-        worker = spawn(null, [], {});
-        expect(worker.slave.spawnargs[1]).to.eql('--arg1');
-        worker.kill();
-        done();
-      });
     });
   }
 

--- a/test/spec/worker.spec.js
+++ b/test/spec/worker.spec.js
@@ -49,6 +49,9 @@ describe('Worker', function () {
         basepath : {
           node : __dirname + '/../thread-scripts',
           web  : 'http://localhost:9876/base/test/thread-scripts'
+        },
+        workerOptions: {
+          execArgv: []
         }
       });
   });


### PR DESCRIPTION
The purpose of this PR is to allow the ability to pass spawn parameters to worker processes when utilizing the **thread pool**. 

Use case
```
this._threadPool = new thread.Pool(4)
this._threadPool.run(require.resolve('./BabelWorker'));
this._threadPool.send(input)
```
It appears that there is no convenient way to pass parameters to processes managed by thread pool. 
Therefore, if --max_old_space_size=4096 is set for the parent process then there is no way to adjust this option.