### PR TITLE
Pass process flags to the thread, taking care of inspect ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,25 @@ Done.
 You can provide a fallback if the user's browser does not support web workers.
 See [webworker-fallback](https://github.com/andywer/webworker-fallback). This will not have any effect if used by node.js code.
 
+### Debugging threads
+
+When the main process uses `--inspect` to debug Node.js, each thread will be started with the `--inspect` flag too, but
+in a different port so they don't interfere with the main process. Each created thread will have an incremental port, so
+you can create and debug as many as you want.
+
+This also works with `--inspect-brk`. As expected, each thread will pause on the first line when created.
+
+All other flags are passed to the thread unchanged. To override this behaviour, you can pass your own `execArgv` array
+when creating a thread:
+
+```javascript
+// Always open an inspect port on 1234, no matter what the main process is doing.
+spawn(myThreadFile, { execArgv: ['--inspect=1234'] })
+
+// Pass this flag to the thread. Ignore any other flag provided by the main process.
+spawn(myThreadFile, { execArgv: ['--throw-deprecation'] })
+```
+
 ### Use external dependencies
 
 Not yet completely implemented.

--- a/package.json
+++ b/package.json
@@ -29,8 +29,12 @@
   },
   "babel": {
     "presets": [
-      "es2015",
-      "es2015-loose"
+      [
+        "es2015",
+        {
+          "loose": true
+        }
+      ]
     ]
   },
   "devDependencies": {

--- a/src/worker.node/worker.js
+++ b/src/worker.node/worker.js
@@ -4,12 +4,37 @@ import EventEmitter from 'eventemitter3';
 
 import { getConfig } from '../config';
 
+// Mutable variable with the last port used for inspect/inspect-brk.
+// This value is shared among all workers.
+let lastPort = 0;
+
+// Port used by Node.JS when there is no port specified. See
+// https://nodejs.org/en/docs/inspector/#command-line-options
+const DEFAULT_PORT = 9229;
+const buildExecArgv = () => process.execArgv.map(arg => {
+  const matches = arg.match(/^(--inspect(?:-brk)?)(?:=(\d+))?/);
+  if (!matches) return arg;
+
+  const command = matches[1];
+  if (lastPort === 0) lastPort = Number(matches[2]) || 9229;
+  lastPort++;
+  return `${command}=${lastPort}`
+});
+
+// This function will reset the counter of ports used for inspect/inspect-brk.
+// Used for testing.
+export const resetPortCounter = () => {
+  lastPort = 0;
+}
 
 export default class Worker extends EventEmitter {
   constructor(initialRunnable, options = {}) {
     super();
 
-    this.slave = child.fork(path.join(__dirname, 'slave.js'), [], options);
+    this.slave = child.fork(path.join(__dirname, 'slave.js'), [], Object.assign(
+      { execArgv: buildExecArgv() },
+      options
+    ));
     this.slave.on('message', this.handleMessage.bind(this));
     this.slave.on('error', this.handleError.bind(this));
     this.slave.on('exit', this.emit.bind(this, 'exit'));

--- a/test/spec/worker.spec.js
+++ b/test/spec/worker.spec.js
@@ -309,7 +309,7 @@ describe('Worker', function () {
 
       it('can override execArgv', () => {
         process.execArgv=['--inspect'];
-        const worker = spawn( echoThread, { execArgv: ['--my-args'] } );
+        const worker = spawn( echoThread, [], { execArgv: ['--my-args'] } );
 
         expect(forkStub.lastCall.args[2]).to.eql({ execArgv: ['--my-args'] })
       });

--- a/test/spec/worker.spec.js
+++ b/test/spec/worker.spec.js
@@ -1,7 +1,9 @@
 import async  from 'async';
 import expect from 'expect.js';
 import sinon  from 'sinon';
-import Worker from '../../lib/worker';
+import Worker, { resetPortCounter } from '../../lib/worker';
+import child_process from 'child_process';
+import EventEmitter from 'eventemitter3';
 import { config, spawn } from '../../';
 
 const env = typeof window === 'object' ? 'browser' : 'node';
@@ -231,6 +233,88 @@ describe('Worker', function () {
         });
     });
 
+    // Note: these tests set a value in `process.execArgv` to test it is correctly used to generate
+    // the values for the worker. If you run these tests in an IDE (for example, VS Code), it might
+    // add extra values to `process.execArgv` and it will cause unexpected results in these tests.
+    describe('can handle process argv', () => {
+      let forkStub;
+      class ForkMock extends EventEmitter {
+        send(){}
+      }
+
+      beforeEach(() => {
+        forkStub = sinon.stub(child_process, 'fork').returns(new ForkMock());
+        resetPortCounter();
+      })
+
+      afterEach(() => {
+        forkStub.restore();
+      })
+
+      it('can receive main process flags', () => {
+        process.execArgv=['--arg1', '--arg2'];
+        const worker = spawn();
+
+        expect(forkStub.calledOnce).to.be.ok();
+        expect(forkStub.lastCall.args[2]).to.eql({
+          execArgv: ['--arg1', '--arg2']
+        })
+      });
+
+      it('increments manual port for --inspect', () => {
+        process.execArgv=['--inspect=1234'];
+        const worker = spawn();
+
+        expect(forkStub.lastCall.args[2]).to.eql({
+          execArgv: ['--inspect=1235']
+        })
+      });
+
+      it('increments manual port for --inspect-brk', () => {
+        process.execArgv=['--inspect-brk=1234'];
+        const worker = spawn();
+
+        expect(forkStub.lastCall.args[2]).to.eql({
+          execArgv: ['--inspect-brk=1235']
+        })
+      });
+
+      it('increments default port for --inspect', () => {
+        process.execArgv=['--inspect'];
+        const worker = spawn();
+
+        expect(forkStub.lastCall.args[2]).to.eql({
+          execArgv: ['--inspect=9230']
+        })
+      });
+
+      it('increments default port for --inspect-brk', () => {
+        process.execArgv=['--inspect-brk'];
+        const worker = spawn();
+
+        expect(forkStub.lastCall.args[2]).to.eql({
+          execArgv: ['--inspect-brk=9230']
+        })
+      });
+
+      it('increments the port in multiple workers', () => {
+        process.execArgv=['--inspect'];
+        const worker1 = spawn();
+        const worker2 = spawn();
+        const worker3 = spawn();
+
+        expect(forkStub.firstCall.args[2]).to.eql({ execArgv: ['--inspect=9230'] })
+        expect(forkStub.secondCall.args[2]).to.eql({ execArgv: ['--inspect=9231'] })
+        expect(forkStub.thirdCall.args[2]).to.eql({ execArgv: ['--inspect=9232'] })
+      });
+
+      it('can override execArgv', () => {
+        process.execArgv=['--inspect'];
+        const worker = spawn( echoThread, { execArgv: ['--my-args'] } );
+
+        expect(forkStub.lastCall.args[2]).to.eql({ execArgv: ['--my-args'] })
+      });
+    })
   }
 
 


### PR DESCRIPTION
It passes any flag (`execArgv`) from the main process to all threads. When that flag is `--inspect` or `--inspect-brk`, it changes the value of the port so the processes don't try to use the same address. 

This behaviour can be disabled by the user by passing a custom `execArgv`.

Bonus: fixes the build process in local

Fixes #16 