### PR TITLE
Hiding this.module.exports from importScripts in initByMethod

### DIFF
--- a/src/worker.browser/slave.js.txt
+++ b/src/worker.browser/slave.js.txt
@@ -52,12 +52,14 @@ self.onmessage = function (event) {
   }
 
   if (event.data.initByMethod) {
-    var method = event.data.method;
-    this.module.exports = Function.apply(null, method.args.concat(method.body));
-
+    delete this.module.exports;
+  
     if (scripts && scripts.length > 0) {
       importScripts.apply(null, scripts);
     }
+
+    var method = event.data.method;
+    this.module.exports = Function.apply(null, method.args.concat(method.body));
   }
 
   if (event.data.doRun) {

--- a/src/worker.browser/slave.js.txt
+++ b/src/worker.browser/slave.js.txt
@@ -52,7 +52,8 @@ self.onmessage = function (event) {
   }
 
   if (event.data.initByMethod) {
-    delete this.module.exports;
+    // Clear `this.module.exports` first, to avoid trouble with importScripts' CommonJS detection
+    delete this.module.exports;
   
     if (scripts && scripts.length > 0) {
       importScripts.apply(null, scripts);


### PR DESCRIPTION
Needed to avoid triggering of false CommonJS detection inside some modules (e.g. https://github.com/emn178/js-sha3). When I'm sending to a thread, initialized with `thread.run(someFunction, ['sha3.js'])`, module is expected to behave like plain JS script that just sets some globals. But due to `this.module.exports` initialization performed before calling `importScripts`, it thinks that CommonJS behavior is expected and replaces `this.module.exports` with its own table of methods.

Actually, I'm not sure if this problem should be fixed here or in js-sha3 itself, but checking for `this.module.exports` seems to be pretty reasonable way to detect CommonJS environment, so other projects may be doing it too.