### PR TITLE
Avoid to use node workers in browser

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -5,7 +5,7 @@
  * configuring a browserify override.
  */
 
-if (typeof process !== 'undefined' && 'pid' in process) {
+if (typeof process !== 'undefined' && process.arch !== 'browser' && 'pid' in process) {
   module.exports = require('./defaults.node');
 } else {
   module.exports = require('./defaults.browser');

--- a/src/worker.js
+++ b/src/worker.js
@@ -5,7 +5,7 @@
  * configuring a browserify override.
  */
 
-if (typeof process !== 'undefined' && 'pid' in process) {
+if (typeof process !== 'undefined' && process.arch !== 'browser' && 'pid' in process) {
   module.exports = require('./worker.node/worker');
 } else {
   module.exports = require('./worker.browser/worker');


### PR DESCRIPTION
Runtime environment detection may fail and try to use NodeJS workers in a Browser environment. This pull request modifies the detection test to avoids this kind of case.

**Detailed problem and solution**

I am currently migrating a subproject from a project created with vue-cli 2 to a project created to vue-cli 3 (VueJS).

Everything works in the old project.

On the new project, same computer, same browser, [this line fails](https://github.com/andywer/threads.js/blob/master/src/defaults.node.js#L5) due to the lack of `cpu()` method.

After some breakpoints, I discovered a difference between the two versions:

- The old one exposes a `process` without `pid` element, threads.js uses Browser elements and everything works.
- The new one exposes a `process` with a fake `pid` element (always 1). threads.js tries to uses the Node elements, but the new environment exposes an `os` empty object (without `cpu()` method). 

Honestly I have absolutely no idea of why a same project build with vue-cli 2 and vue-cli 3 doesn't exposes the same environment. As this migration changes Babel and Webpack versions and vue-cli 3 hides lot of build scripts, this can be anything. I don't have any "minimal test case" and cannot build one on a reasonable amount of time.

The `process` in browser environment always uses an `arch` element with `browser` value, thus this fix should work.