### PR TITLE
Update package `natives` to fix node 11 crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6789,9 +6789,9 @@
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "natives": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
-      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
       "dev": true
     },
     "natural-compare": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "karma-firefox-launcher": "^1.0.0",
     "karma-mocha": "^1.3.0",
     "mocha": "^3.1.2",
+    "natives": "^1.1.6",
     "sinon": "^1.16.1",
     "through2": "^2.0.0",
     "vinyl-source-stream": "^1.1.0"


### PR DESCRIPTION
See <https://github.com/gulpjs/gulp/issues/2246>. Should make the build in #96 go green again.