### PR TITLE
Only set process listeners if `process.on()` is a function

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -172,7 +172,7 @@ if (typeof self !== "undefined" && typeof self.addEventListener === "function" &
   })
 }
 
-if (typeof process !== "undefined" && Implementation.isWorkerRuntime()) {
+if (typeof process !== "undefined" && typeof process.on === "function" && Implementation.isWorkerRuntime()) {
   process.on("uncaughtException", (error) => {
     // Post with some delay, so the master had some time to subscribe to messages
     setTimeout(() => postUncaughtErrorMessage(error), 250)


### PR DESCRIPTION
Seems like webpack's `process` polyfill for web builds is not an event emitter. What kind of makes sense on second thought.

Fixes #148.