### PR TITLE
Support prefix path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3599,8 +3599,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3621,14 +3620,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3643,20 +3640,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3773,8 +3767,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3786,7 +3779,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3801,7 +3793,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3809,14 +3800,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3835,7 +3824,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3916,8 +3904,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3929,7 +3916,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4015,8 +4001,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4052,7 +4037,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4072,7 +4056,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4116,14 +4099,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/master/implementation.browser.ts
+++ b/src/master/implementation.browser.ts
@@ -6,7 +6,7 @@ const isAbsoluteURL = (value: string) => /^(https?:)?\/\//i.test(value)
 
 function selectWorkerImplementation(): typeof WorkerImplementation {
   return class BrowserWorker extends Worker {
-    constructor(url: string | URL, options?: WorkerOptions, prefixFunc? : Function) {
+    constructor(url: string | URL, options?: WorkerOptions, prefixFunc? : () => string | string) {
       if (typeof url === "string" && isAbsoluteURL(url)) {
         // Create source code blob loading JS file via `importScripts()`
         // to circumvent worker CORS restrictions

--- a/src/master/implementation.browser.ts
+++ b/src/master/implementation.browser.ts
@@ -6,7 +6,7 @@ const isAbsoluteURL = (value: string) => /^(https?:)?\/\//i.test(value)
 
 function selectWorkerImplementation(): typeof WorkerImplementation {
   return class BrowserWorker extends Worker {
-    constructor(url: string | URL, options?: WorkerOptions) {
+    constructor(url: string | URL, options?: WorkerOptions, prefixFunc? : Function) {
       if (typeof url === "string" && isAbsoluteURL(url)) {
         // Create source code blob loading JS file via `importScripts()`
         // to circumvent worker CORS restrictions
@@ -16,7 +16,12 @@ function selectWorkerImplementation(): typeof WorkerImplementation {
         )
         url = URL.createObjectURL(blob)
       }
-      super(url, options)
+
+      if (typeof prefixFunc === "function") {
+        super(`${prefixFunc()}/${url}`, options);
+      } else {
+        super(url, options);
+      }
     }
   }
 }

--- a/src/master/implementation.browser.ts
+++ b/src/master/implementation.browser.ts
@@ -19,6 +19,8 @@ function selectWorkerImplementation(): typeof WorkerImplementation {
 
       if (typeof prefixFunc === "function") {
         super(`${prefixFunc()}/${url}`, options);
+      } else if (typeof prefixFunc === "string") {
+        super(`${prefixFunc}/${url}`, options);
       } else {
         super(url, options);
       }

--- a/test/spawn.chromium.mocha.ts
+++ b/test/spawn.chromium.mocha.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai"
 import { spawn, Thread } from "../src/index"
+import { Worker } from '../src/index'
 
 // We need this as a work-around to make our threads Worker global, since
 // the Parcel bundler would otherwise not recognize `new Worker()` as a web worker
@@ -8,6 +9,18 @@ import "../src/master/register"
 describe("threads in browser", function() {
   it("can spawn and terminate a thread", async function() {
     const helloWorld = await spawn<() => string>(new Worker("./workers/hello-world.js"))
+    expect(await helloWorld()).to.equal("Hello World")
+    await Thread.terminate(helloWorld)
+  })
+
+  it("can spawn and terminate a thread with a prefix", async function() {
+    const helloWorld = await spawn<() => string>(
+      new Worker(
+        "./hello-world.js",
+        {},
+        () => {return "workers"; }
+       )
+     );
     expect(await helloWorld()).to.equal("Hello World")
     await Thread.terminate(helloWorld)
   })

--- a/test/spawn.chromium.mocha.ts
+++ b/test/spawn.chromium.mocha.ts
@@ -13,12 +13,24 @@ describe("threads in browser", function() {
     await Thread.terminate(helloWorld)
   })
 
-  it("can spawn and terminate a thread with a prefix", async function() {
+  it("can spawn and terminate a thread with a prefix string", async function() {
     const helloWorld = await spawn<() => string>(
       new Worker(
         "./hello-world.js",
         {},
-        () => {return "workers"; }
+        "workers"
+       )
+     );
+    expect(await helloWorld()).to.equal("Hello World")
+    await Thread.terminate(helloWorld)
+  })
+
+  it("can spawn and terminate a thread with a prefix function", async function() {
+    const helloWorld = await spawn<() => string>(
+      new Worker(
+        "./hello-world.js",
+        {},
+        () => "workers"
        )
      );
     expect(await helloWorld()).to.equal("Hello World")


### PR DESCRIPTION
A possible solution to https://github.com/andywer/threads.js/issues/156 where the `Worker` class takes an additional optional parameter to retrieve a function prefixing the worker url with some path so that it can be loaded from a non-standard location.

Example:

```
    const helloWorld = await spawn<() => string>(
      new Worker(
        "./hello-world.js",
        {},
        "workers"
       )
     );
```