### PR TITLE
Fixed TypeError when observer was not provided into subject

### DIFF
--- a/src/observable.ts
+++ b/src/observable.ts
@@ -1,6 +1,6 @@
 import Observable from "zen-observable"
 
-const $observers = Symbol("observers")
+const $observers = Symbol("observers");
 
 /**
  * Observable subject. Implements the Observable interface, but also exposes
@@ -28,15 +28,25 @@ class Subject<T> extends Observable<T> implements ZenObservable.ObservableLike<T
   }
 
   public complete() {
-    this[$observers].forEach(observer => observer.complete())
+      if(this.hasObservables()) {
+          this[ $observers ].forEach( observer => observer.complete() )
+      }
   }
 
   public error(error: any) {
-    this[$observers].forEach(observer => observer.error(error))
+      if(this.hasObservables()) {
+          this[ $observers ].forEach( observer => observer.error( error ) )
+      }
   }
 
   public next(value: T) {
-    this[$observers].forEach(observer => observer.next(value))
+      if(this.hasObservables()){
+          this[$observers].forEach(observer => observer.next(value))
+      }
+  }
+
+  protected hasObservables(): boolean{
+      return this[$observers] && Array.isArray(this[$observers];
   }
 }
 

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -1,6 +1,6 @@
 import Observable from "zen-observable"
 
-const $observers = Symbol("observers");
+const $observers = Symbol("observers")
 
 /**
  * Observable subject. Implements the Observable interface, but also exposes
@@ -25,28 +25,20 @@ class Subject<T> extends Observable<T> implements ZenObservable.ObservableLike<T
       }
       return unsubscribe
     })
+
+    this[$observers] = []
   }
 
   public complete() {
-      if(this.hasObservables()) {
-          this[ $observers ].forEach( observer => observer.complete() )
-      }
+    this[$observers].forEach(observer => observer.complete())
   }
 
   public error(error: any) {
-      if(this.hasObservables()) {
-          this[ $observers ].forEach( observer => observer.error( error ) )
-      }
+    this[$observers].forEach(observer => observer.error(error))
   }
 
   public next(value: T) {
-      if(this.hasObservables()){
-          this[$observers].forEach(observer => observer.next(value))
-      }
-  }
-
-  protected hasObservables(): boolean{
-      return this[$observers] && Array.isArray(this[$observers]);
+    this[$observers].forEach(observer => observer.next(value))
   }
 }
 

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -46,7 +46,7 @@ class Subject<T> extends Observable<T> implements ZenObservable.ObservableLike<T
   }
 
   protected hasObservables(): boolean{
-      return this[$observers] && Array.isArray(this[$observers];
+      return this[$observers] && Array.isArray(this[$observers]);
   }
 }
 


### PR DESCRIPTION
Assuming that I have following code:

> worker.ts

```javascript
import { expose } from 'threads/worker';
import FileWriter from './FileWriter';
import { Observable } from 'threads/dist/observable';

let fileWriter = new FileWriter();

const fileWorker = {
    writeFile: async ( fileName: string, limit: number ) =>
               {
                   fileWriter.fileName = fileName;
                   fileWriter.limit = limit;
                   await fileWriter.writeFile();

                   fileWriter = new FileWriter();
               },
    observer:  () =>
               {
                   return Observable.from( fileWriter.subject );
               }

};

export type FileWorker = typeof fileWorker;

expose( fileWorker );
```

> FileWriter.ts
```javascript
import * as Fs from 'fs';
import * as Path from 'path';
import { Subject } from 'threads/observable';

export default class FileWriter
{
    public readonly subject: Subject<number> = new Subject<number>();

    public constructor( public fileName: string = '', public limit: number = 100000 )
    {
    }

    protected get path(): string
    {
        return Path.resolve( __dirname, `../${ this.fileName }` );
    }

    public async writeFile(): Promise<void>
    {
        let lines = 0;
        const path = this.path;

        while ( lines <= this.limit ) {
            await Fs.promises.appendFile( path, 'Hello! \n' );
            lines++;
            this.subject.next( lines );
        }

        this.subject.complete();
    }

}
```

> main.ts
```javascript
import { spawn, Thread, Worker } from 'threads';
import { FileWorker } from './worker';

const main = async (): Promise<void> =>
{
    const worker = await spawn<FileWorker>( new Worker( './worker' ) );
    const { writeFile, observer } = worker;
    const limit = 100000;

    try {
        observer().subscribe( console.log );

        await writeFile( `test${ Math.random() }.txt`, limit );
    } catch ( e ) {
        console.error( 'Error occured:', e )
    } finally {
        Thread.terminate( worker );
    }
};

main().catch( console.error );
```

If I remove line `observer().subscribe( console.log );` from main.ts I get following error:
```
Error occured: Error [TypeError]: Cannot read property 'forEach' of undefined
    at Subject.next (C:\Users\Przemek\Documents\Projects\node-multithread\node_modules\threads\dist\observable.js:38:26)
    at FileWriter.writeFile (C:\Users\Przemek\Documents\Projects\node-multithread\src\FileWriter.ts:26:26)
    at writeFile (C:\Users\Przemek\Documents\Projects\node-multithread\src\worker.ts:12:20) {
  name: 'TypeError'
}
```

This commit should fix that :).