### PR TITLE
Gracefully shutdown process on SIGTERM

### DIFF
--- a/src/master/implementation.node.ts
+++ b/src/master/implementation.node.ts
@@ -104,18 +104,18 @@ function initWorkerThreadsWorker(): typeof WorkerImplementation {
     }
   }
 
-  const terminateAll = () => {
+  const terminateWorkersAndMaster = () => {
     // we should terminate all workers and then gracefully shutdown self process
     Promise.all(allWorkers.map(worker => worker.terminate())).then(
-        () => process.exit(0),
-        () => process.exit(1),
+      () => process.exit(0),
+      () => process.exit(1),
     )
     allWorkers = []
   }
 
   // Take care to not leave orphaned processes behind. See #147.
-  process.on("SIGINT", () => terminateAll())
-  process.on("SIGTERM", () => terminateAll())
+  process.on("SIGINT", () => terminateWorkersAndMaster())
+  process.on("SIGTERM", () => terminateWorkersAndMaster())
 
   return Worker as any
 }
@@ -159,19 +159,19 @@ function initTinyWorker(): typeof WorkerImplementation {
     }
   }
 
-  const terminateAll = () => {
+  const terminateWorkersAndMaster = () => {
     // we should terminate all workers and then gracefully shutdown self process
     Promise.all(allWorkers.map(worker => worker.terminate())).then(
-        () => process.exit(0),
-        () => process.exit(1),
+      () => process.exit(0),
+      () => process.exit(1),
     )
     allWorkers = []
   }
 
   // Take care to not leave orphaned processes behind
   // See <https://github.com/avoidwork/tiny-worker#faq>
-  process.on("SIGINT", () => terminateAll())
-  process.on("SIGTERM", () => terminateAll())
+  process.on("SIGINT", () => terminateWorkersAndMaster())
+  process.on("SIGTERM", () => terminateWorkersAndMaster())
 
   return Worker as any
 }

--- a/src/master/implementation.node.ts
+++ b/src/master/implementation.node.ts
@@ -105,7 +105,11 @@ function initWorkerThreadsWorker(): typeof WorkerImplementation {
   }
 
   const terminateAll = () => {
-    allWorkers.forEach(worker => worker.terminate())
+    // we should terminate all workers and then gracefully shutdown self process
+    Promise.all(allWorkers.map(worker => worker.terminate())).then(
+        () => process.exit(0),
+        () => process.exit(1),
+    )
     allWorkers = []
   }
 
@@ -156,7 +160,11 @@ function initTinyWorker(): typeof WorkerImplementation {
   }
 
   const terminateAll = () => {
-    allWorkers.forEach(worker => worker.terminate())
+    // we should terminate all workers and then gracefully shutdown self process
+    Promise.all(allWorkers.map(worker => worker.terminate())).then(
+        () => process.exit(0),
+        () => process.exit(1),
+    )
     allWorkers = []
   }
 


### PR DESCRIPTION
We should manually shutdown process if `SIGTERM`/`SIGINT` listeners are installed

nodejs docs (https://nodejs.org/dist/latest-v12.x/docs/api/process.html#process_signal_events)
> 'SIGTERM' and 'SIGINT' have default handlers on non-Windows platforms that reset the terminal mode before exiting with code 128 + signal number. **If one of these signals has a listener installed, its default behavior will be removed** (Node.js will no longer exit).

tiny-worker docs (https://github.com/avoidwork/tiny-worker#faq)
> In your core script register a listener for SIGTERM or SIGINT via process.on() which terminates (all) worker process(es) and then gracefully shutdowns via process.exit(0);

**Example:**
Problem: `cluster` workers don't shutdown because `theads.js` has invalid SIGTERM listener.

```js
// cluster.js

const cluster = require('cluster');

if (cluster.isMaster) {
    console.log(`Master ${ process.pid } is running`);

    cluster.fork();

    cluster.on('exit', (worker, code, signal) => {
        console.log(`worker ${ worker.process.pid } died`);
    });
} else {
    const { spawn, Worker } = require('threads');

    spawn(new Worker('./worker.js'));
    console.log(`Worker ${ process.pid } started`);
}

```

```js
// worker.js

const { expose } = require('threads/worker');

expose(() => 'hello from worker');
```

Run
```
$ node --version
v12.14.1
$ node cluster.js
Master 64701 is running
Worker 64702 started
```

```
$ kill 64702
# nothing happens... But we should see "worker 64702 died"
# PR fixes this problem
```