### PR TITLE
Ignore `child_process` in browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   },
   "browser": {
     "callsites": false,
+    "child_process": false,
     "tiny-worker": false,
     "ts-node": false,
     "ts-node/register": false,

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   "browser": {
     "callsites": false,
     "child_process": false,
+    "os": false,
     "tiny-worker": false,
     "ts-node": false,
     "ts-node/register": false,


### PR DESCRIPTION
Part of a fix for andywer/threads-plugin#13.