### PR TITLE
Handle postMessage() errors in main thread

### DIFF
--- a/src/master/invocation-proxy.ts
+++ b/src/master/invocation-proxy.ts
@@ -114,7 +114,11 @@ export function createProxyFunction<Args extends any[], ReturnType>(worker: Work
       args
     }
     debugMessages("Sending command to run function to worker:", runMessage)
-    worker.postMessage(runMessage, transferables)
+    try {
+      worker.postMessage(runMessage, transferables)
+    } catch(e) {
+      return Promise.reject(e);
+    }
     return ObservablePromise.from(multicast(createObservableForJob<ReturnType>(worker, uid)))
   }) as any as ProxyableFunction<Args, ReturnType>
 }

--- a/src/master/invocation-proxy.ts
+++ b/src/master/invocation-proxy.ts
@@ -84,7 +84,7 @@ function prepareArguments(rawArgs: any[]): { args: any[], transferables: Transfe
       transferables: []
     }
   }
-  
+
   const args: any[] = []
   const transferables: Transferable[] = []
 
@@ -113,12 +113,15 @@ export function createProxyFunction<Args extends any[], ReturnType>(worker: Work
       method,
       args
     }
+
     debugMessages("Sending command to run function to worker:", runMessage)
+
     try {
       worker.postMessage(runMessage, transferables)
-    } catch(e) {
-      return Promise.reject(e);
+    } catch (error) {
+      return ObservablePromise.from(Promise.reject(error))
     }
+
     return ObservablePromise.from(multicast(createObservableForJob<ReturnType>(worker, uid)))
   }) as any as ProxyableFunction<Args, ReturnType>
 }

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -50,6 +50,19 @@ test("thread job errors are handled", async t => {
   await Thread.terminate(fail)
 })
 
+test("thread transfer errors are handled", async t => {
+  const builtin = require('module').builtinModules;
+  if (builtin.indexOf('worker_threads') > -1) {
+    // test is actual for native worker_threads only
+    const helloWorld = await spawn(new Worker("./workers/hello-world"))
+    const badTransferObj = { fn: () => {} };
+    await t.throwsAsync(helloWorld(badTransferObj), {name: 'DataCloneError'})
+    await Thread.terminate(helloWorld)
+  } else {
+    t.pass();
+  }
+})
+
 test("catches top-level thread errors", async t => {
   await t.throwsAsync(spawn(new Worker("./workers/top-level-throw")), "Top-level worker error")
 })


### PR DESCRIPTION
Replacement of #197.

It's essentially the same commits (thanks, @doochik!), but uses `ObservablePromise.from()` when handling `postMessage()` errors.