### PR TITLE
Allow overriding init timeout via parameters

### DIFF
--- a/src/master/spawn.ts
+++ b/src/master/spawn.ts
@@ -137,13 +137,16 @@ function setPrivateThreadProps<T>(raw: T, worker: WorkerType, workerEvents: Obse
  * the worker has initialized successfully.
  *
  * @param worker Instance of `Worker`. Either a web worker, `worker_threads` worker or `tiny-worker` worker.
+ * @param [options]
+ * @param [options.timeout] Init message timeout. Default: 10000 or set by environment variable.
  */
 export async function spawn<Exposed extends WorkerFunction | WorkerModule<any> = ArbitraryWorkerInterface>(
-  worker: WorkerType
+  worker: WorkerType,
+  options?: { timeout?: number }
 ): Promise<ExposedToThreadType<Exposed>> {
   debugSpawn("Initializing new thread")
 
-  const initMessage = await withTimeout(receiveInitMessage(worker), initMessageTimeout, `Timeout: Did not receive an init message from worker after ${initMessageTimeout}ms. Make sure the worker calls expose().`)
+  const initMessage = await withTimeout(receiveInitMessage(worker), options && options.timeout ? options.timeout : initMessageTimeout, `Timeout: Did not receive an init message from worker after ${initMessageTimeout}ms. Make sure the worker calls expose().`)
   const exposed = initMessage.exposed
 
   const { termination, terminate } = createTerminator(worker)


### PR DESCRIPTION
We have some environments (involving Docker containers or Webpack builds, &c., &c.) where (a) setting the timeout via env var is awkward, and (b) some development machines experience timeouts. It would be nice to be able to override the default timeout via parameters.