### PR TITLE
Feature: Custom serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .cache/
+.vscode/
 docs/_site
 docs/vendor
 dist/*

--- a/docs/usage-advanced.md
+++ b/docs/usage-advanced.md
@@ -132,6 +132,20 @@ import { registerSerializer } from "threads"
 registerSerializer(MySerializer)
 ```
 
+You can also register multiple serializers. Just call `registerSerializer()` multiple times – make sure to register the same serializers in the worker and main thread.
+
+The registered serializers will then be chained. The serializer that was registered at last is invoked first. If it does not know how to serialize the data, it will call its fallback handler which is the second-to-last serializer and so forth.
+
+```typescript
+import { registerSerializer } from "threads"
+
+registerSerializer(SomeSerializer)
+registerSerializer(AnotherSerializer)
+
+// threads.js will first try to use AnotherSerializer, will fall back to SomeSerializer,
+// eventually falls back to passing the data as is if no serializer can handle it
+```
+
 
 ## Debug logging
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,20 +1,21 @@
-export interface SerializedError {
-  message: string
-  name: string
-  stack?: string
+import {
+  extendSerializer,
+  DefaultSerializer,
+  JsonSerializable,
+  Serializer,
+  SerializerImplementation
+} from "./serializers"
+
+let registeredSerializer: Serializer<JsonSerializable> = DefaultSerializer
+
+export function registerSerializer(serializer: SerializerImplementation<JsonSerializable>) {
+  registeredSerializer = extendSerializer(registeredSerializer, serializer)
 }
 
-export function rehydrateError(error: SerializedError): Error {
-  return Object.assign(Error(error.message), {
-    name: error.name,
-    stack: error.stack
-  })
+export function deserialize(message: JsonSerializable): any {
+  return registeredSerializer.deserialize(message)
 }
 
-export function serializeError(error: Error): SerializedError {
-  return {
-    message: error.message,
-    name: error.name,
-    stack: error.stack
-  }
+export function serialize(input: any): JsonSerializable {
+  return registeredSerializer.serialize(input)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export { registerSerializer } from "./common"
 export * from "./master/index"
 export { expose } from "./worker/index"
+export { DefaultSerializer, JsonSerializable, Serializer, SerializerImplementation } from "./serializers"
 export { Transfer, TransferDescriptor } from "./transferable"

--- a/src/master/spawn.ts
+++ b/src/master/spawn.ts
@@ -1,6 +1,6 @@
 import DebugLogger from "debug"
 import { Observable } from "observable-fns"
-import { rehydrateError } from "../common"
+import { deserialize } from "../common"
 import { createPromiseWithResolver } from "../promise"
 import { $errors, $events, $terminate, $worker } from "../symbols"
 import {
@@ -67,7 +67,7 @@ function receiveInitMessage(worker: WorkerType): Promise<WorkerInitMessage> {
         resolve(event.data)
       } else if (isUncaughtErrorMessage(event.data)) {
         worker.removeEventListener("message", messageHandler)
-        reject(rehydrateError(event.data.error))
+        reject(deserialize(event.data.error))
       }
     }) as EventListener
     worker.addEventListener("message", messageHandler)

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -1,0 +1,84 @@
+import { SerializedError } from "./types/messages"
+
+export interface Serializer<Msg = JsonSerializable, Input = any> {
+  deserialize(message: Msg): Input
+  serialize(input: Input): Msg
+}
+
+export interface SerializerImplementation<Msg = JsonSerializable, Input = any> {
+  deserialize(message: Msg, defaultDeserialize: ((msg: Msg) => Input)): Input
+  serialize(input: Input, defaultSerialize: ((inp: Input) => Msg)): Msg
+}
+
+export function extendSerializer<MessageType, InputType = any>(
+  extend: Serializer<MessageType, InputType>,
+  implementation: SerializerImplementation<MessageType, InputType>
+): Serializer<MessageType, InputType> {
+  const fallbackDeserializer = extend.deserialize.bind(extend)
+  const fallbackSerializer = extend.serialize.bind(extend)
+
+  return {
+    deserialize(message: MessageType): InputType {
+      return implementation.deserialize(message, fallbackDeserializer)
+    },
+
+    serialize(input: InputType): MessageType {
+      return implementation.serialize(input, fallbackSerializer)
+    }
+  }
+}
+
+type JsonSerializablePrimitive = string | number | boolean | null
+
+type JsonSerializableObject = {
+  [key: string]:
+    | JsonSerializablePrimitive
+    | JsonSerializablePrimitive[]
+    | JsonSerializableObject
+    | JsonSerializableObject[]
+    | undefined
+}
+
+export type JsonSerializable =
+  | JsonSerializablePrimitive
+  | JsonSerializablePrimitive[]
+  | JsonSerializableObject
+  | JsonSerializableObject[]
+
+
+const DefaultErrorSerializer: Serializer<SerializedError, Error> = {
+  deserialize(message: SerializedError): Error {
+    return Object.assign(Error(message.message), {
+      name: message.name,
+      stack: message.stack
+    })
+  },
+  serialize(error: Error): SerializedError {
+    return {
+      __error_marker: "$$error",
+      message: error.message,
+      name: error.name,
+      stack: error.stack
+    }
+  }
+}
+
+const isSerializedError = (thing: any): thing is SerializedError =>
+  thing && typeof thing === "object" && "__error_marker" in thing && thing.__error_marker === "$$error"
+
+export const DefaultSerializer: Serializer<JsonSerializable> = {
+  deserialize(message: JsonSerializable): any {
+    if (isSerializedError(message)) {
+      return DefaultErrorSerializer.deserialize(message)
+    } else {
+      return message
+    }
+  },
+  serialize(input: any): JsonSerializable {
+    if (input instanceof Error) {
+      return DefaultErrorSerializer.serialize(input) as any as JsonSerializable
+    } else {
+      return input
+    }
+  }
+}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,3 +1,10 @@
+export interface SerializedError {
+  __error_marker: "$$error"
+  message: string
+  name: string
+  stack?: string
+}
+
 /////////////////////////////
 // Messages sent by master:
 
@@ -42,11 +49,7 @@ export type WorkerInitMessage = {
 export type WorkerJobErrorMessage = {
   type: WorkerMessageType.error,
   uid: number,
-  error: {
-    message: string,
-    name: string,
-    stack?: string
-  }
+  error: SerializedError
 }
 
 export type WorkerJobResultMessage = {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,10 +1,11 @@
 import isSomeObservable from "is-observable"
 import { Observable } from "observable-fns"
-import { serializeError } from "../common"
+import { deserialize, serialize } from "../common"
 import { isTransferDescriptor, TransferDescriptor } from "../transferable"
 import {
   MasterJobRunMessage,
   MasterMessageType,
+  SerializedError,
   WorkerInitMessage,
   WorkerJobErrorMessage,
   WorkerJobResultMessage,
@@ -15,6 +16,7 @@ import {
 import { WorkerFunction, WorkerModule } from "../types/worker"
 import Implementation from "./implementation"
 
+export { registerSerializer } from "../common"
 export { Transfer } from "../transferable"
 
 let exposeCalled = false
@@ -63,7 +65,7 @@ function postJobErrorMessage(uid: number, rawError: Error | TransferDescriptor<E
   const errorMessage: WorkerJobErrorMessage = {
     type: WorkerMessageType.error,
     uid,
-    error: serializeError(error)
+    error: serialize(error) as any as SerializedError
   }
   Implementation.postMessageToMaster(errorMessage, transferables)
 }
@@ -91,7 +93,7 @@ function postJobStartMessage(uid: number, resultType: WorkerJobStartMessage["res
 function postUncaughtErrorMessage(error: Error) {
   const errorMessage: WorkerUncaughtErrorMessage = {
     type: WorkerMessageType.uncaughtError,
-    error: serializeError(error)
+    error: serialize(error) as any as SerializedError
   }
   Implementation.postMessageToMaster(errorMessage)
 }
@@ -110,16 +112,16 @@ async function runFunction(jobUID: number, fn: WorkerFunction, args: any[]) {
 
   if (isObservable(syncResult)) {
     syncResult.subscribe(
-      value => postJobResultMessage(jobUID, false, value),
-      error => postJobErrorMessage(jobUID, error),
+      value => postJobResultMessage(jobUID, false, serialize(value)),
+      error => postJobErrorMessage(jobUID, serialize(error) as any),
       () => postJobResultMessage(jobUID, true)
     )
   } else {
     try {
       const result = await syncResult
-      postJobResultMessage(jobUID, true, result)
+      postJobResultMessage(jobUID, true, serialize(result))
     } catch (error) {
-      postJobErrorMessage(jobUID, error)
+      postJobErrorMessage(jobUID, serialize(error) as any)
     }
   }
 }
@@ -143,14 +145,14 @@ export function expose(exposed: WorkerFunction | WorkerModule<any>) {
   if (typeof exposed === "function") {
     Implementation.subscribeToMasterMessages(messageData => {
       if (isMasterJobRunMessage(messageData) && !messageData.method) {
-        runFunction(messageData.uid, exposed, messageData.args)
+        runFunction(messageData.uid, exposed, messageData.args.map(deserialize))
       }
     })
     postFunctionInitMessage()
   } else if (typeof exposed === "object" && exposed) {
     Implementation.subscribeToMasterMessages(messageData => {
       if (isMasterJobRunMessage(messageData) && messageData.method) {
-        runFunction(messageData.uid, exposed[messageData.method], messageData.args)
+        runFunction(messageData.uid, exposed[messageData.method], messageData.args.map(deserialize))
       }
     })
 

--- a/test/lib/serialization.ts
+++ b/test/lib/serialization.ts
@@ -1,0 +1,42 @@
+import { JsonSerializable, SerializerImplementation } from "../../src/index"
+
+export class Foo<T> {
+  private readonly value: T
+
+  constructor(value: T) {
+    this.value = value
+  }
+
+  getValue() {
+    return this.value
+  }
+}
+
+interface SerializedFoo<T extends JsonSerializable> {
+  __type: "$$foo"
+  val: T
+}
+
+const isSerializedFoo = (thing: any): thing is SerializedFoo<JsonSerializable> =>
+  thing && typeof thing === "object" && "__type" in thing && thing.__type === "$$foo"
+
+export const fooSerializer: SerializerImplementation = {
+  deserialize(serialized, fallback) {
+    if (isSerializedFoo(serialized)) {
+      return new Foo(serialized.val)
+    } else {
+      return fallback(serialized)
+    }
+  },
+
+  serialize(data, fallback) {
+    if (data instanceof Foo) {
+      return {
+        __type: "$$foo",
+        val: data.getValue()
+      }
+    } else {
+      return fallback(data)
+    }
+  }
+}

--- a/test/serialization.test.ts
+++ b/test/serialization.test.ts
@@ -1,0 +1,19 @@
+import test from "ava"
+import { fooSerializer, Foo } from "./lib/serialization"
+import { registerSerializer, spawn, Thread, Worker } from "../src/index"
+
+registerSerializer(fooSerializer)
+
+test("can use a custom serializer", async t => {
+  const run = await spawn(new Worker("./workers/serialization.ts"))
+
+  try {
+    const input = new Foo("Test")
+    const result: Foo<string> = await run(input)
+
+    t.true(result instanceof Foo)
+    t.is(result.getValue(), "TestTest")
+  } finally {
+    await Thread.terminate(run)
+  }
+})

--- a/test/workers/serialization.ts
+++ b/test/workers/serialization.ts
@@ -1,0 +1,10 @@
+import { fooSerializer, Foo } from "../lib/serialization"
+import { expose, registerSerializer } from "../../src/worker"
+
+registerSerializer(fooSerializer)
+
+async function run(foo: Foo<string>) {
+  return new Foo(foo.getValue() + foo.getValue())
+}
+
+expose(run)


### PR DESCRIPTION
Allow registering custom serializers to (de-)serialize class instances and other non-trivial data structures that could normally not be sent using `.postMessage()`.

Anyone got any thoughts on this feature or the API? 😉