### PR TITLE
Make node worker try the `*.asar.unpacked` path

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -171,6 +171,21 @@ Be aware that this might affect any code that tries to instantiate a normal web 
 
 Everything else should work out of the box.
 
+### Electron
+
+When building an Electron application you probably want to enable ASAR packaging – it's usually enabled by default. Your JavaScript files will then be packaged into an ASAR archive which can help reducing the executable size and time to launch.
+
+The problem is that you can `require()` / `import` JavaScript modules from within the ASAR archive, but you cannot spawn workers packaged in the archive as easily. In order to spawn workers, you can use the [`asarUnpack`](https://www.electron.build/configuration/configuration#configuration-asarUnpack) option to unpack the archive when the app launches. `threads.js` will automatically look for the worker in the unpacked archive directory.
+
+The following sample snippet shows how to set that option in your `package.json` file. You will have to use the right paths for your application's files.
+
+```diff
++ "asarUnpack": {
++   "dist/main/0.bundle.worker.js",
++   "dist/main/0.bundle.worker.js.map"
++ }
+```
+
 ## Next
 
 Learn about the details and all the other features of the threads.js API, like

--- a/src/master/implementation.node.ts
+++ b/src/master/implementation.node.ts
@@ -1,4 +1,4 @@
-// tslint:disable function-constructor no-eval max-classes-per-file
+// tslint:disable function-constructor no-eval no-duplicate-super max-classes-per-file
 
 import getCallsites, { CallSite } from "callsites"
 import EventEmitter from "events"
@@ -82,6 +82,13 @@ function initWorkerThreadsWorker(): typeof WorkerImplementation {
 
       if (resolvedScriptPath.match(/\.tsx?$/i) && detectTsNode()) {
         super(createTsNodeModule(resolvedScriptPath), { eval: true })
+      } else if (resolvedScriptPath.match(/\.asar\//)) {
+        try {
+          super(resolvedScriptPath, options)
+        } catch {
+          // See <https://github.com/andywer/threads-plugin/issues/17>
+          super(resolvedScriptPath.replace(/\.asar([/\/])/, ".asar.unpack$1"), options)
+        }
       } else {
         super(resolvedScriptPath, options)
       }
@@ -137,6 +144,13 @@ function initTinyWorker(): typeof WorkerImplementation {
 
       if (resolvedScriptPath.match(/\.tsx?$/i) && detectTsNode()) {
         super(new Function(createTsNodeModule(resolveScriptPath(scriptPath))), [], { esm: true })
+      } else if (resolvedScriptPath.match(/\.asar\//)) {
+        try {
+          super(resolvedScriptPath, [], { esm: true })
+        } catch {
+          // See <https://github.com/andywer/threads-plugin/issues/17>
+          super(resolvedScriptPath.replace(/\.asar([/\/])/, ".asar.unpack$1"), [], { esm: true })
+        }
       } else {
         super(resolvedScriptPath, [], { esm: true })
       }

--- a/src/master/implementation.node.ts
+++ b/src/master/implementation.node.ts
@@ -96,7 +96,7 @@ function initWorkerThreadsWorker(): typeof WorkerImplementation {
           super(resolvedScriptPath, options)
         } catch {
           // See <https://github.com/andywer/threads-plugin/issues/17>
-          super(resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpack$1"), options)
+          super(resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpacked$1"), options)
         }
       } else {
         super(resolvedScriptPath, options)
@@ -158,7 +158,7 @@ function initTinyWorker(): typeof WorkerImplementation {
           super(resolvedScriptPath, [], { esm: true })
         } catch {
           // See <https://github.com/andywer/threads-plugin/issues/17>
-          super(resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpack$1"), [], { esm: true })
+          super(resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpacked$1"), [], { esm: true })
         }
       } else {
         super(resolvedScriptPath, [], { esm: true })

--- a/src/master/implementation.node.ts
+++ b/src/master/implementation.node.ts
@@ -82,12 +82,12 @@ function initWorkerThreadsWorker(): typeof WorkerImplementation {
 
       if (resolvedScriptPath.match(/\.tsx?$/i) && detectTsNode()) {
         super(createTsNodeModule(resolvedScriptPath), { eval: true })
-      } else if (resolvedScriptPath.match(/\.asar\//)) {
+      } else if (resolvedScriptPath.match(/\.asar[\/\\]/)) {
         try {
           super(resolvedScriptPath, options)
         } catch {
           // See <https://github.com/andywer/threads-plugin/issues/17>
-          super(resolvedScriptPath.replace(/\.asar([/\/])/, ".asar.unpack$1"), options)
+          super(resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpack$1"), options)
         }
       } else {
         super(resolvedScriptPath, options)
@@ -144,12 +144,12 @@ function initTinyWorker(): typeof WorkerImplementation {
 
       if (resolvedScriptPath.match(/\.tsx?$/i) && detectTsNode()) {
         super(new Function(createTsNodeModule(resolveScriptPath(scriptPath))), [], { esm: true })
-      } else if (resolvedScriptPath.match(/\.asar\//)) {
+      } else if (resolvedScriptPath.match(/\.asar[\/\\]/)) {
         try {
           super(resolvedScriptPath, [], { esm: true })
         } catch {
           // See <https://github.com/andywer/threads-plugin/issues/17>
-          super(resolvedScriptPath.replace(/\.asar([/\/])/, ".asar.unpack$1"), [], { esm: true })
+          super(resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpack$1"), [], { esm: true })
         }
       } else {
         super(resolvedScriptPath, [], { esm: true })


### PR DESCRIPTION
Try the `*.asar.unpack` path if the path contains `.asar/`. See <https://www.electron.build/configuration/configuration#configuration-asarUnpack>.

Fixes andywer/threads-plugin#17.