### PR TITLE
Pass NativeWorker options to ts-node worker implementation

### DIFF
--- a/src/master/implementation.node.ts
+++ b/src/master/implementation.node.ts
@@ -81,7 +81,7 @@ function initWorkerThreadsWorker(): typeof WorkerImplementation {
       const resolvedScriptPath = resolveScriptPath(scriptPath)
 
       if (resolvedScriptPath.match(/\.tsx?$/i) && detectTsNode()) {
-        super(createTsNodeModule(resolvedScriptPath), { eval: true })
+        super(createTsNodeModule(resolvedScriptPath), { ...options, eval: true })
       } else {
         super(resolvedScriptPath, options)
       }


### PR DESCRIPTION
Hello,
current implementation ignores worker options when ts-node is present. For example is not possible to pass "workerData" to thread.
This PR fixes this case.

Regards
Tomasz