### PR TITLE
Update Typescript-Example in Usage-Docs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -167,11 +167,12 @@ import { spawn, Thread, Worker } from "threads"
 import { Counter } from "./workers/counter"
 
 const counter = await spawn<Counter>(new Worker("./workers/counter"))
-console.log(await counter.getCount())
-await counter.increment()
-console.log(await counter.getCount())
-await Thread.terminate(counter);
+console.log(`Initial counter: ${await counter.getCount()}`)
 
+await counter.increment()
+console.log(`Updated counter: ${await counter.getCount()}`)
+
+await Thread.terminate(counter)
 ```
 
 ```ts

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -167,7 +167,11 @@ import { spawn, Thread, Worker } from "threads"
 import { Counter } from "./workers/counter"
 
 const counter = await spawn<Counter>(new Worker("./workers/counter"))
+console.log(await counter.getCount())
 await counter.increment()
+console.log(await counter.getCount())
+await Thread.terminate(counter);
+
 ```
 
 ```ts


### PR DESCRIPTION
Added missing `Thread.terminate` & output to make the example more clear