### PR TITLE
Support async iterables

### DIFF
--- a/src/master/invocation-proxy.ts
+++ b/src/master/invocation-proxy.ts
@@ -103,8 +103,8 @@ function prepareArguments(rawArgs: any[]): { args: any[], transferables: Transfe
   }
 }
 
-const doneAsyncIterator = (async function*() {
-  // this async generator function is used to avoid unnecessary calls of worker's async iterator that has been already done
+const doneIterator = (function*() {
+  // this generator function is used to avoid unnecessary calls of worker's async iterator that has been already done
 })()
 function mixinAsyncIterableIterator<T1, T2>(observable: Observable<T1>, worker: WorkerType, uid: number): Observable<T1> & AsyncIterableIterator<T2> {
   let done = false
@@ -112,7 +112,7 @@ function mixinAsyncIterableIterator<T1, T2>(observable: Observable<T1>, worker: 
   const createMethod = (method: "next" | "return" | "throw") => async (rawArg?: any) => {
     const result = previousCall.then(() => {
       if (done) {
-        return doneAsyncIterator[method](rawArg)
+        return doneIterator[method](rawArg)
       }
       const { args, transferables } = prepareArguments(rawArg ? [rawArg] : [])
       const runMessage: MasterJobRunMessage = {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -62,7 +62,7 @@ export type WorkerJobResultMessage = {
 export type WorkerJobStartMessage = {
   type: WorkerMessageType.running,
   uid: number,
-  resultType: "observable" | "promise"
+  resultType: "observable" | "promise" | "asyncIterable"
 }
 
 export type WorkerSentMessage =

--- a/test/workers/count-to-five-generator.ts
+++ b/test/workers/count-to-five-generator.ts
@@ -1,0 +1,11 @@
+import { expose } from "../../src/worker"
+
+expose(async function* countToFive() {
+  for (let counter = 1; counter <= 5; counter++) {
+    await new Promise(resolve => setTimeout(resolve, 1))
+    const reset = yield(counter)
+    if (reset) {
+      counter = 0
+    }
+  }
+})


### PR DESCRIPTION
Resolves #251 

I gave up supporting non-async iterables since there are JavaScript built-in iterables (such as strings and arrays and array-like objects) that we do not want to handle in this way.