### PR TITLE
Unsubscribe from worker observables when master unsubscribes

### DIFF
--- a/src/master/invocation-proxy.ts
+++ b/src/master/invocation-proxy.ts
@@ -17,6 +17,7 @@ import {
   Worker as WorkerType
 } from "../types/master"
 import {
+  MasterJobCancelMessage,
   MasterJobRunMessage,
   MasterMessageType,
   WorkerJobErrorMessage,
@@ -71,8 +72,17 @@ function createObservableForJob<ResultType>(worker: WorkerType, jobUID: number):
         worker.removeEventListener("message", messageHandler)
       }
     }) as EventListener
+
     worker.addEventListener("message", messageHandler)
-    return () => worker.removeEventListener("message", messageHandler)
+
+    return () => {
+      const cancelMessage: MasterJobCancelMessage = {
+        type: MasterMessageType.cancel,
+        uid: jobUID
+      }
+      worker.postMessage(cancelMessage)
+      worker.removeEventListener("message", messageHandler)
+    }
   })
 }
 

--- a/src/master/invocation-proxy.ts
+++ b/src/master/invocation-proxy.ts
@@ -76,11 +76,13 @@ function createObservableForJob<ResultType>(worker: WorkerType, jobUID: number):
     worker.addEventListener("message", messageHandler)
 
     return () => {
-      const cancelMessage: MasterJobCancelMessage = {
-        type: MasterMessageType.cancel,
-        uid: jobUID
+      if (asyncType === "observable" || !asyncType) {
+        const cancelMessage: MasterJobCancelMessage = {
+          type: MasterMessageType.cancel,
+          uid: jobUID
+        }
+        worker.postMessage(cancelMessage)
       }
-      worker.postMessage(cancelMessage)
       worker.removeEventListener("message", messageHandler)
     }
   })

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -9,7 +9,13 @@ export interface SerializedError {
 // Messages sent by master:
 
 export enum MasterMessageType {
+  cancel = "cancel",
   run = "run"
+}
+
+export type MasterJobCancelMessage = {
+  type: MasterMessageType.cancel,
+  uid: number
 }
 
 export type MasterJobRunMessage = {
@@ -19,7 +25,7 @@ export type MasterJobRunMessage = {
   args: any[]
 }
 
-export type MasterSentMessage = MasterJobRunMessage
+export type MasterSentMessage = MasterJobCancelMessage | MasterJobRunMessage
 
 ////////////////////////////
 // Messages sent by worker:


### PR DESCRIPTION
Proxy `.unsubscribe()` calls to worker observables. Fixes #262.