### PR TITLE
Subscribe to task completion eagerly

### DIFF
--- a/src/master/pool.ts
+++ b/src/master/pool.ts
@@ -1,6 +1,6 @@
 import DebugLogger from "debug"
 import { multicast, Observable, Subject } from "observable-fns"
-import { allSettled, SettlementResult } from "../ponyfills"
+import { allSettled } from "../ponyfills"
 import { defaultPoolSize } from "./implementation"
 import {
   PoolEvent,
@@ -328,7 +328,12 @@ class WorkerPool<ThreadType extends Thread> implements Pool<ThreadType> {
 
     const taskID = this.nextTaskID++
     const taskCompletion = this.taskCompletion(taskID)
-    let taskCompletionDotThen: Promise<any>["then"] | undefined
+
+    taskCompletion.catch((error) => {
+      // Prevent unhandled rejections here as we assume the user will use
+      // `pool.completed()`, `pool.settled()` or `task.catch()` to handle errors
+      this.debug(`Task #${taskID} errored:`, error)
+    })
 
     const task: QueuedTask<ThreadType, any> = {
       id: taskID,


### PR DESCRIPTION
Fixes #270.

When you subscribed to a task's completion too late, it might have been resolved already, but the newly created promise would not know that and stay in a pending state forever.