### PR TITLE
feat: catch worker errors

### DIFF
--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -67,4 +67,16 @@ test("catches top-level thread errors", async t => {
   await t.throwsAsync(spawn(new Worker("./workers/top-level-throw")), "Top-level worker error")
 })
 
+test("catches segfaults in a tiny-worker implementation", async t => {
+  const builtin = require('module').builtinModules;
+  if (builtin.indexOf('worker_threads') === -1) {
+    // test is actual for child process workers only (tiny-worker)
+    const segfault = await spawn<() => Promise<never>>(new Worker("./workers/sigsegv"))
+    await t.throwsAsync(segfault(), "Terminated with signal SIGSEGV")
+    await Thread.terminate(segfault)
+  } else {
+    t.pass()
+  }
+})
+
 test.todo("can subscribe to thread events")

--- a/test/workers/sigsegv.ts
+++ b/test/workers/sigsegv.ts
@@ -1,0 +1,5 @@
+import { expose } from "../../src/worker"
+
+expose(async function sigsegv() {
+  process.kill(process.pid, 'SIGSEGV')
+})


### PR DESCRIPTION
Depends on https://github.com/avoidwork/tiny-worker/pull/43
Reject the promise if the worker was killed by the system or unexpectedly exited.

A nice feature of threads@0.x was that you could listen for exit event of the spawned worker and reject the promise based on it.
```js
await new Promise((resolve, reject) => thread
  .run('./src/ChildProcessHelper')
  .send({ data })
  .on('exit', (code, signal) => {
    if (code !== 0) {
      reject(new Error(`child process exited with ${code} ${signal}`));
    } else {
      resolve([]);
    }
  })
  .promise()
  .then(resolve, reject));
```

With worker_threads this isn't possible at all, as they are running in the same process, so if something bad happens there, the main process is affected (e.g. segfault).

That's one more reason for enabling tiny-worker on latest node versions. https://github.com/andywer/threads.js/issues/229

The code just illustrates the idea.