### PR TITLE
Do not kill the master process

### DIFF
--- a/src/master/implementation.node.ts
+++ b/src/master/implementation.node.ts
@@ -217,10 +217,7 @@ function initTinyWorker(): ImplementationExport {
 
   const terminateWorkersAndMaster = () => {
     // we should terminate all workers and then gracefully shutdown self process
-    Promise.all(allWorkers.map(worker => worker.terminate())).then(
-      () => process.exit(0),
-      () => process.exit(1),
-    )
+    Promise.all(allWorkers.map(worker => worker.terminate())).catch(e => console.error(e));
     allWorkers = []
   }
 


### PR DESCRIPTION
There may be graceful shutdown happening elsewhere - other processes can be orphaned by doing this.