### PR TITLE
Export postMessage and subscribeToMasterMessages

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -23,6 +23,9 @@ export { Transfer } from "../transferable"
 /** Returns `true` if this code is currently running in a worker. */
 export const isWorkerRuntime = Implementation.isWorkerRuntime
 
+export const postMessage = Implementation.postMessageToMaster;
+export const subscribeToMasterMessages = Implementation.subscribeToMasterMessages;
+
 let exposeCalled = false
 
 const activeSubscriptions = new Map<number, Subscription<any>>()


### PR DESCRIPTION
This PR addresses #311 it exports the direct worker interface
functions that can then be used in the worker like:

``` javascript
import { subscribeToMasterMessages, postMessage } from 'threads/worker'

subscribeToMasterMessages((event: any) => {
  if(event && event.type){
   console.log(event.type); 
  }else{
    console.warn('unsure what to do with message passed to worker...', event);
  }
});
  
postMessage({
  type: "@NETWORK/server/tick",
  payload:{...}
}), null);
```