### PR TITLE
fix: missing isWorkerRuntimer export in esm

### DIFF
--- a/worker.mjs
+++ b/worker.mjs
@@ -3,3 +3,4 @@ import WorkerContext from "./dist/worker/index.js"
 export const expose = WorkerContext.expose
 export const registerSerializer = WorkerContext.registerSerializer
 export const Transfer = WorkerContext.Transfer
+export const isWorkerRuntime = WorkerContext.isWorkerRuntime


### PR DESCRIPTION
There is this missing export.