### PR TITLE
Allow url in WorkerImplementation constructor

### DIFF
--- a/src/types/master.ts
+++ b/src/types/master.ts
@@ -100,7 +100,7 @@ export interface ThreadsWorkerOptions extends WorkerOptions {
 
 /** Worker implementation. Either web worker or a node.js Worker class. */
 export declare class WorkerImplementation extends EventTarget implements Worker {
-  constructor(path: string, options?: ThreadsWorkerOptions)
+  constructor(path: string | URL, options?: ThreadsWorkerOptions)
   public postMessage(value: any, transferList?: TransferList): void
   public terminate(): void | Promise<number>
 }


### PR DESCRIPTION
So the threads.js exported Worker works with bundlers that automatically bundle with import.meta.