### PR TITLE
silence "Message from worker before finishing initialization" if the message is an init message

### DIFF
--- a/src/master/spawn.ts
+++ b/src/master/spawn.ts
@@ -61,11 +61,14 @@ async function withTimeout<T>(promise: Promise<T>, timeoutInMs: number, errorMes
 function receiveInitMessage(worker: WorkerType): Promise<WorkerInitMessage> {
   return new Promise((resolve, reject) => {
     const messageHandler = ((event: MessageEvent) => {
-      debugMessages("Message from worker before finishing initialization:", event.data)
       if (isInitMessage(event.data)) {
         worker.removeEventListener("message", messageHandler)
         resolve(event.data)
-      } else if (isUncaughtErrorMessage(event.data)) {
+      } else {
+        debugMessages("Message from worker before finishing initialization:", event.data)
+      }
+
+      if (isUncaughtErrorMessage(event.data)) {
         worker.removeEventListener("message", messageHandler)
         reject(deserialize(event.data.error))
       }


### PR DESCRIPTION
using `DEBUG=threads:*` to debug some `threads` stuff, and was confused for a second about seeing debug messages with "Message from worker before finishing initialization". Turns out the messages it was receiving before initialization were actually the init messages. 

This led me into a small rabbit hole, where I thought I was somehow sending messages to the pool too soon, so I looked in the docs to figure out if there was a way to await pool initialization, but didn't find anything, etc. 