### PR TITLE
added support to spawn threads from electron asar bundles

### DIFF
--- a/src/master/implementation.node.ts
+++ b/src/master/implementation.node.ts
@@ -115,8 +115,13 @@ function initWorkerThreadsWorker(): ImplementationExport {
       } else if (resolvedScriptPath.match(/\.tsx?$/i) && detectTsNode()) {
         super(createTsNodeModule(resolvedScriptPath), { ...options, eval: true })
       } else if (resolvedScriptPath.match(/\.asar[\/\\]/)) {
-        // See <https://github.com/andywer/threads-plugin/issues/17>
-        super(resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpacked$1"), options)
+        const electronPath =
+          options?.electronAsarUnpacked === false
+            ? resolvedScriptPath
+            // See <https://github.com/andywer/threads-plugin/issues/17>
+            : resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpacked$1")
+
+        super(electronPath, options)
       } else {
         super(resolvedScriptPath, options)
       }

--- a/src/types/master.ts
+++ b/src/types/master.ts
@@ -94,6 +94,10 @@ export interface ThreadsWorkerOptions extends WorkerOptions {
   /** Data passed on to node.js worker_threads. */
   workerData?: any
 
+  /** If Electron workers should use the asar.unpacked path. Default to true.
+   *  See <https://github.com/andywer/threads-plugin/issues/17> */
+  electronAsarUnpacked?: boolean
+
   /** Whether to apply CORS protection workaround. Defaults to true. */
   CORSWorkaround?: boolean
 }


### PR DESCRIPTION
Hey @andywer, thanks for the great repo. As described in https://github.com/andywer/threads.js/issues/425, electron now supports spawning threads from asar bundles. This PR adds support for asar bundles.

In order to keep the default behavior the same (no breaking changes), I added an opt-in value `electronAsarUnpacked` to the worker constructor, which when set to `false` passes the raw value to `NativeWorker`.


For anyone reading this (other than @andywer) who needs this behavior before the PR is merged in, here is a patch (for use with [patch-package](https://www.npmjs.com/package/patch-package)):
```
diff --git a/node_modules/threads/dist/master/implementation.node.js b/node_modules/threads/dist/master/implementation.node.js
index df93ca1..218f4fd 100644
--- a/node_modules/threads/dist/master/implementation.node.js
+++ b/node_modules/threads/dist/master/implementation.node.js
@@ -108,8 +108,15 @@ function initWorkerThreadsWorker() {
                 super(createTsNodeModule(resolvedScriptPath), Object.assign(Object.assign({}, options), { eval: true }));
             }
             else if (resolvedScriptPath.match(/\.asar[\/\\]/)) {
+              const electronPath =
+              options?.electronAsarUnpacked === false
+                ? resolvedScriptPath
                 // See <https://github.com/andywer/threads-plugin/issues/17>
-                super(resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpacked$1"), options);
+                : resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpacked$1")
+
+              super(electronPath, options)
+                // See <https://github.com/andywer/threads-plugin/issues/17>
+                // super(resolvedScriptPath.replace(/\.asar([\/\\])/, ".asar.unpacked$1"), options);
             }
             else {
                 super(resolvedScriptPath, options);
diff --git a/node_modules/threads/dist/types/master.d.ts b/node_modules/threads/dist/types/master.d.ts
index a9c9044..768c302 100644
--- a/node_modules/threads/dist/types/master.d.ts
+++ b/node_modules/threads/dist/types/master.d.ts
@@ -62,6 +62,9 @@ export interface ThreadsWorkerOptions extends WorkerOptions {
     workerData?: any;
     /** Whether to apply CORS protection workaround. Defaults to true. */
     CORSWorkaround?: boolean;
+    /** If Electron workers should use the asar.unpacked path. Defaults to true.
+     *  See <https://github.com/andywer/threads-plugin/issues/17> */
+    electronAsarUnpacked?: boolean
 }
 /** Worker implementation. Either web worker or a node.js Worker class. */
 export declare class WorkerImplementation extends EventTarget implements Worker {
```