### PR TITLE
fix: add "types" field to conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,19 +24,23 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "default": "./index.mjs"
+      "default": "./index.mjs",
+      "types": "./dist/index.d.ts"
     },
     "./observable": {
       "require": "./observable.js",
-      "default": "./observable.mjs"
+      "default": "./observable.mjs",
+      "types": "./observable.d.ts"
     },
     "./register": {
       "require": "./register.js",
-      "default": "./register.mjs"
+      "default": "./register.mjs",
+      "types": "./register.d.ts"
     },
     "./worker": {
       "require": "./worker.js",
-      "default": "./worker.mjs"
+      "default": "./worker.mjs",
+      "types": "./worker.d.ts"
     }
   },
   "sideEffects": [

--- a/package.json
+++ b/package.json
@@ -24,23 +24,23 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "default": "./index.mjs",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./index.mjs"
     },
     "./observable": {
       "require": "./observable.js",
-      "default": "./observable.mjs",
-      "types": "./observable.d.ts"
+      "types": "./observable.d.ts",
+      "default": "./observable.mjs"
     },
     "./register": {
       "require": "./register.js",
-      "default": "./register.mjs",
-      "types": "./register.d.ts"
+      "types": "./register.d.ts",
+      "default": "./register.mjs"
     },
     "./worker": {
       "require": "./worker.js",
-      "default": "./worker.mjs",
-      "types": "./worker.d.ts"
+      "types": "./worker.d.ts",
+      "default": "./worker.mjs"
     }
   },
   "sideEffects": [


### PR DESCRIPTION
I'm experiencing a lot of issues when trying to resolve the types 

```
src/fft/single_fft.ts:1:26 - error TS7016: Could not find a declaration file for module 'threads'. '/home/tom/Programming/turbo-prover-js/node_modules/threads/index.mjs' implicitly has an 'any' type.
  There are types at '/home/tom/Programming/turbo-prover-js/node_modules/threads/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'threads' library may need to update its package.json or typings.

1 import { Transfer } from 'threads';
                           ~~~~~~~~~

src/pippenger/single_pippenger.ts:3:26 - error TS7016: Could not find a declaration file for module 'threads'. '/home/tom/Programming/turbo-prover-js/node_modules/threads/index.mjs' implicitly has an 'any' type.
  There are types at '/home/tom/Programming/turbo-prover-js/node_modules/threads/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'threads' library may need to update its package.json or typings.

3 import { Transfer } from 'threads';
                           ~~~~~~~~~

src/wasm/worker.ts:2:37 - error TS7016: Could not find a declaration file for module 'threads/observable'. '/home/tom/Programming/turbo-prover-js/node_modules/threads/observable.mjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/threads` if it exists or add a new declaration (.d.ts) file containing `declare module 'threads/observable';`

2 import { Subject, Observable } from 'threads/observable';
                                      ~~~~~~~~~~~~~~~~~~~~

src/wasm/worker.ts:3:34 - error TS7016: Could not find a declaration file for module 'threads/worker'. '/home/tom/Programming/turbo-prover-js/node_modules/threads/worker.mjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/threads` if it exists or add a new declaration (.d.ts) file containing `declare module 'threads/worker';`

3 import { expose, Transfer } from 'threads/worker';
                                   ~~~~~~~~~~~~~~~~

src/wasm/worker_factory.ts:2:39 - error TS7016: Could not find a declaration file for module 'threads'. '/home/tom/Programming/turbo-prover-js/node_modules/threads/index.mjs' implicitly has an 'any' type.
  There are types at '/home/tom/Programming/turbo-prover-js/node_modules/threads/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'threads' library may need to update its package.json or typings.

2 import { spawn, Thread, Worker } from 'threads';
```

The last error explicitly calls out that changes need to be made to the threads.js `package.json`. I've then added a "types" field for each of the conditional exports.

