### PR TITLE
Fix TypeScript type file declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
       "default": "./index.mjs"
     },
     "./observable": {


### PR DESCRIPTION
The type file export is missing from the package.json, which breaks TypeScript.