### PR TITLE
fix: master thread message handler only logs 1 debug message per jobUID

### DIFF
--- a/src/master/invocation-proxy.ts
+++ b/src/master/invocation-proxy.ts
@@ -41,8 +41,8 @@ function createObservableForJob<ResultType>(worker: WorkerType, jobUID: number):
     let asyncType: "observable" | "promise" | undefined
 
     const messageHandler = ((event: MessageEvent) => {
-      debugMessages("Message from worker:", event.data)
       if (!event.data || event.data.uid !== jobUID) return
+      debugMessages("Message from worker:", event.data)
 
       if (isJobStartMessage(event.data)) {
         asyncType = event.data.resultType


### PR DESCRIPTION
Here's a pull request to fix an issue with the worker `message` event handler.. it's logging 1 debug message per worker event handler.

So if a user has 10 observable events from the worker that the master subscribes to it will log 10 times the same message.

Doing the debug log after filtering the event UID fixes the issue.

Would appreciate a merge and new version if you could be so kind! Thank you!