### PR TITLE
Add link to types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist-esm/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist/ dist-esm/",
     "dev": "npm run clean && tsc -p tsconfig.json --watch",
@@ -24,19 +25,23 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "default": "./index.mjs"
+      "default": "./index.mjs",
+      "types": "./dist/index.d.ts"
     },
     "./observable": {
       "require": "./observable.js",
-      "default": "./observable.mjs"
+      "default": "./observable.mjs",
+      "types": "./observable.d.ts"
     },
     "./register": {
       "require": "./register.js",
-      "default": "./register.mjs"
+      "default": "./register.mjs",
+      "types": "./register.d.ts"
     },
     "./worker": {
       "require": "./worker.js",
-      "default": "./worker.mjs"
+      "default": "./worker.mjs",
+      "types": "./worker.d.ts"
     }
   },
   "sideEffects": [


### PR DESCRIPTION
When you open the library on a Typescript project, I get the following error message on VSCode:
```
Could not find a declaration file for module 'threads'. '/home/mlage/test/test-threadsjs/node_modules/.pnpm/threads@1.7.0_patch_hash=eohjd6xpj3mgfbvhyvlcjihlim/node_modules/threads/index.mjs' implicitly has an 'any' type.
  There are types at '/home/mlage/test/test-threadsjs/node_modules/threads/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'threads' library may need to update its package.json or typings.ts(7016)
```
This is just updating the `package.json` to fix this.
Thank you