### PR TITLE
Fix cjs imports for modules

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,4 +1,4 @@
-import Threads from "./dist/index.js"
+import * as Threads from "./dist/index.js"
 
 export const registerSerializer = Threads.registerSerializer
 export const spawn = Threads.spawn

--- a/observable.mjs
+++ b/observable.mjs
@@ -1,4 +1,4 @@
-import Observables from "./dist/observable.js"
+import * as Observables from "./dist/observable.js"
 
 export const Observable = Observables.Observable
 export const Subject = Observables.Subject

--- a/worker.mjs
+++ b/worker.mjs
@@ -1,4 +1,4 @@
-import WorkerContext from "./dist/worker/index.js"
+import * as WorkerContext from "./dist/worker/index.js"
 
 export const expose = WorkerContext.expose
 export const registerSerializer = WorkerContext.registerSerializer


### PR DESCRIPTION
When bundling an app with [parcel](https://parceljs.org/), if [package exports](https://parceljs.org/features/dependency-resolution/#package-exports) are enabled, importing `threads` causes an error.

This happens because when following package exports, parcel expects the module to use default exports if a default import is being used.

The files `dist/observable.js`, `dist/index.js`, `dist/worker/index.js` offer only named exports, so trying to import a default (eg `import Threads from "./dist/index.js"`) fails.

Using a `*` import is a safer way to handle this across bundlers.